### PR TITLE
Quick fix for slider bug in interactive viewers

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -117,7 +117,7 @@ jobs:
           brew install libomp
           brew install c-blosc
           brew install hdf5
-          brew install libtiff
+          brew reinstall libtiff
 
       - name: Run cibuildwheel
         run: |

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -55,7 +55,7 @@ jobs:
       CIBW_TEST_COMMAND: "python3 -m pytest -vv {project}/pyapr/tests"
       CIBW_TEST_SKIP: "*-win_amd64"  # windows tests are run separately
       CIBW_BEFORE_BUILD_LINUX: "yum makecache && yum install -y libtiff-devel hdf5-devel"
-      CIBW_ENVIRONMENT_MACOS: CPPFLAGS="-I/opt/homebrew/opt/llvm/include" LDFLAGS="-L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++" CXX="/opt/homebrew/opt/llvm/bin/clang++" CC="/opt/homebrew/opt/llvm/bin/clang"
+      CIBW_ENVIRONMENT_MACOS: CPPFLAGS="-I/opt/homebrew/opt/llvm/include" LDFLAGS="-L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++" CXX="/opt/homebrew/opt/llvm/bin/clang++" CC="/opt/homebrew/opt/llvm/bin/clang" EXTRA_CMAKE_ARGS="-DCMAKE_PREFIX_PATH=/opt/homebrew/Cellar/libtiff/4.6.0"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -55,7 +55,7 @@ jobs:
       CIBW_TEST_COMMAND: "python3 -m pytest -vv {project}/pyapr/tests"
       CIBW_TEST_SKIP: "*-win_amd64"  # windows tests are run separately
       CIBW_BEFORE_BUILD_LINUX: "yum makecache && yum install -y libtiff-devel hdf5-devel"
-      CIBW_ENVIRONMENT_MACOS: CPPFLAGS="-I/opt/homebrew/opt/llvm/include" LDFLAGS="-L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++" CXX="/opt/homebrew/opt/llvm/bin/clang++" CC="/opt/homebrew/opt/llvm/bin/clang" EXTRA_CMAKE_ARGS="-DCMAKE_PREFIX_PATH=/opt/homebrew/Cellar/libtiff/4.6.0"
+      CIBW_ENVIRONMENT_MACOS: CPPFLAGS="-I/opt/homebrew/opt/llvm/include" LDFLAGS="-L/opt/homebrew/opt/llvm/lib" CXX="/opt/homebrew/opt/llvm/bin/clang++" CC="/opt/homebrew/opt/llvm/bin/clang" EXTRA_CMAKE_ARGS="-DCMAKE_PREFIX_PATH=/opt/homebrew/Cellar/libtiff/4.6.0"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -55,7 +55,7 @@ jobs:
       CIBW_TEST_COMMAND: "python3 -m pytest -vv {project}/pyapr/tests"
       CIBW_TEST_SKIP: "*-win_amd64"  # windows tests are run separately
       CIBW_BEFORE_BUILD_LINUX: "yum makecache && yum install -y libtiff-devel hdf5-devel"
-      CIBW_ENVIRONMENT_MACOS: CPPFLAGS="-I/opt/homebrew/opt/llvm/include" LDFLAGS="-L/opt/homebrew/Cellar/libtiff/4.6.0/lib -L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++" CXX="/opt/homebrew/opt/llvm/bin/clang++" CC="/opt/homebrew/opt/llvm/bin/clang"
+      CIBW_ENVIRONMENT_MACOS: CPPFLAGS="-I/opt/homebrew/Cellar/libtiff/4.6.0/include -I/opt/homebrew/opt/llvm/include" LDFLAGS="-L/opt/homebrew/Cellar/libtiff/4.6.0/lib -L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++" CXX="/opt/homebrew/opt/llvm/bin/clang++" CC="/opt/homebrew/opt/llvm/bin/clang"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -55,7 +55,7 @@ jobs:
       CIBW_TEST_COMMAND: "python3 -m pytest -vv {project}/pyapr/tests"
       CIBW_TEST_SKIP: "*-win_amd64"  # windows tests are run separately
       CIBW_BEFORE_BUILD_LINUX: "yum makecache && yum install -y libtiff-devel hdf5-devel"
-      CIBW_ENVIRONMENT_MACOS: CPPFLAGS="-I/opt/homebrew/opt/llvm/include -I/opt/homebrew/opt/libomp/include" LDFLAGS="-L/opt/homebrew/opt/llvm/lib -L/opt/homebrew/opt/libomp/lib" CXX="/opt/homebrew/opt/llvm/bin/clang++" CC="/opt/homebrew/opt/llvm/bin/clang" EXTRA_CMAKE_ARGS="-DCMAKE_PREFIX_PATH=/opt/homebrew/Cellar/libtiff/4.6.0"
+      CIBW_ENVIRONMENT_MACOS: CPPFLAGS="-I/opt/homebrew/opt/llvm/include" LDFLAGS="-L/opt/homebrew/opt/llvm/lib" CXX="/opt/homebrew/opt/llvm/bin/clang++" CC="/opt/homebrew/opt/llvm/bin/clang" EXTRA_CMAKE_ARGS="-DCMAKE_PREFIX_PATH=/opt/homebrew/Cellar/libtiff/4.6.0;/opt/homebrew/opt/libomp"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -117,6 +117,7 @@ jobs:
           brew install libomp
           brew install c-blosc
           brew install hdf5
+          brew install libtiff
 
       - name: Run cibuildwheel
         run: |

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -55,7 +55,7 @@ jobs:
       CIBW_TEST_COMMAND: "python3 -m pytest -vv {project}/pyapr/tests"
       CIBW_TEST_SKIP: "*-win_amd64"  # windows tests are run separately
       CIBW_BEFORE_BUILD_LINUX: "yum makecache && yum install -y libtiff-devel hdf5-devel"
-      CIBW_ENVIRONMENT_MACOS: CPPFLAGS="-I/opt/homebrew/opt/llvm/include" LDFLAGS="-L/opt/homebrew/opt/llvm/lib" CXX="/opt/homebrew/opt/llvm/bin/clang++" CC="/opt/homebrew/opt/llvm/bin/clang" EXTRA_CMAKE_ARGS="-DCMAKE_PREFIX_PATH=/opt/homebrew/Cellar/libtiff/4.6.0"
+      CIBW_ENVIRONMENT_MACOS: CPPFLAGS="-I/opt/homebrew/opt/llvm/include -I/opt/homebrew/opt/libomp/include" LDFLAGS="-L/opt/homebrew/opt/llvm/lib -L/opt/homebrew/opt/libomp/lib" CXX="/opt/homebrew/opt/llvm/bin/clang++" CC="/opt/homebrew/opt/llvm/bin/clang" EXTRA_CMAKE_ARGS="-DCMAKE_PREFIX_PATH=/opt/homebrew/Cellar/libtiff/4.6.0"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -55,7 +55,7 @@ jobs:
       CIBW_TEST_COMMAND: "python3 -m pytest -vv {project}/pyapr/tests"
       CIBW_TEST_SKIP: "*-win_amd64"  # windows tests are run separately
       CIBW_BEFORE_BUILD_LINUX: "yum makecache && yum install -y libtiff-devel hdf5-devel"
-      CIBW_ENVIRONMENT_MACOS: CPPFLAGS="-I/opt/homebrew/opt/llvm/include" LDFLAGS="-L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++" CXX="/opt/homebrew/opt/llvm/bin/clang++" CC="/opt/homebrew/opt/llvm/bin/clang"
+      CIBW_ENVIRONMENT_MACOS: CPPFLAGS="-I/opt/homebrew/opt/llvm/include" LDFLAGS="-L/opt/homebrew/Cellar/libtiff/4.6.0/lib -L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++" CXX="/opt/homebrew/opt/llvm/bin/clang++" CC="/opt/homebrew/opt/llvm/bin/clang"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -45,7 +45,7 @@ jobs:
       # Indicates the location of the vcpkg as a Git submodule of the project repository.
       VCPKG_ROOT: ${{ github.workspace }}/external/LibAPR/vcpkg
       CIBW_ENVIRONMENT_WINDOWS: EXTRA_CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=D:\\a\\pyapr\\pyapr\\external\\LibAPR\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake -DVCPKG_MANIFEST_DIR=D:\\a\\pyapr\\pyapr\\external\\LibAPR\\"
-      CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-*"
+      CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-*"
       CIBW_SKIP: "*musllinux*"
       CIBW_ARCHS: "auto64"
       CIBW_BUILD_VERBOSITY: 1

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -55,7 +55,7 @@ jobs:
       CIBW_TEST_COMMAND: "python3 -m pytest -vv {project}/pyapr/tests"
       CIBW_TEST_SKIP: "*-win_amd64"  # windows tests are run separately
       CIBW_BEFORE_BUILD_LINUX: "yum makecache && yum install -y libtiff-devel hdf5-devel"
-      CIBW_ENVIRONMENT_MACOS: CPPFLAGS="-I/usr/local/opt/llvm/include" LDFLAGS="-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib" CXX="/usr/local/opt/llvm/bin/clang++" CC="/usr/local/opt/llvm/bin/clang"
+      CIBW_ENVIRONMENT_MACOS: CPPFLAGS="-I/opt/homebrew/opt/llvm/include" LDFLAGS="-L/opt/homebrew/opt/llvm/lib" CXX="/opt/homebrew/opt/llvm/bin/clang++" CC="/opt/homebrew/opt/llvm/bin/clang"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -55,7 +55,7 @@ jobs:
       CIBW_TEST_COMMAND: "python3 -m pytest -vv {project}/pyapr/tests"
       CIBW_TEST_SKIP: "*-win_amd64"  # windows tests are run separately
       CIBW_BEFORE_BUILD_LINUX: "yum makecache && yum install -y libtiff-devel hdf5-devel"
-      CIBW_ENVIRONMENT_MACOS: CPPFLAGS="-I/opt/homebrew/Cellar/libtiff/4.6.0/include -I/opt/homebrew/opt/llvm/include" LDFLAGS="-L/opt/homebrew/Cellar/libtiff/4.6.0/lib -L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++" CXX="/opt/homebrew/opt/llvm/bin/clang++" CC="/opt/homebrew/opt/llvm/bin/clang"
+      CIBW_ENVIRONMENT_MACOS: CPPFLAGS="-I/opt/homebrew/opt/llvm/include" LDFLAGS="-L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++" CXX="/opt/homebrew/opt/llvm/bin/clang++" CC="/opt/homebrew/opt/llvm/bin/clang"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -72,7 +72,7 @@ jobs:
       - uses: lukka/get-cmake@latest
       # Restore both vcpkg and its artifacts from the GitHub cache service.
       - name: Restore vcpkg and its artifacts.
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # The first path is where vcpkg generates artifacts while consuming the vcpkg.json manifest file.
           # The second path is the location of vcpkg (it contains the vcpkg executable and data files).
@@ -101,10 +101,10 @@ jobs:
       # On Windows runners, let's ensure to have the Developer Command Prompt environment setup correctly. As used here the Developer Command Prompt created is targeting x64 and using the default the Windows SDK.
       - uses: ilammy/msvc-dev-cmd@v1
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: '3.9'
+          python-version: '3.12'
 
       - name: Install cibuildwheel
         run: |
@@ -125,7 +125,7 @@ jobs:
           python3 -m cibuildwheel --output-dir ${{matrix.builddir}}
 
       - name: Upload wheels as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}-wheels
           path: ${{matrix.builddir}}/
@@ -139,7 +139,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ windows-latest ]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
       - name: Checkout
@@ -148,12 +148,12 @@ jobs:
           submodules: false
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Download wheels from artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.os }}-wheels
           path: wheelhouse
@@ -183,14 +183,14 @@ jobs:
     if: contains(github.ref, 'tags')
     steps:
       - name: Download wheels from artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: wheelhouse
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -55,7 +55,7 @@ jobs:
       CIBW_TEST_COMMAND: "python3 -m pytest -vv {project}/pyapr/tests"
       CIBW_TEST_SKIP: "*-win_amd64"  # windows tests are run separately
       CIBW_BEFORE_BUILD_LINUX: "yum makecache && yum install -y libtiff-devel hdf5-devel"
-      CIBW_ENVIRONMENT_MACOS: CPPFLAGS="-I/opt/homebrew/opt/llvm/include" LDFLAGS="-L/opt/homebrew/opt/llvm/lib" CXX="/opt/homebrew/opt/llvm/bin/clang++" CC="/opt/homebrew/opt/llvm/bin/clang"
+      CIBW_ENVIRONMENT_MACOS: CPPFLAGS="-I/opt/homebrew/opt/llvm/include" LDFLAGS="-L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++" CXX="/opt/homebrew/opt/llvm/bin/clang++" CC="/opt/homebrew/opt/llvm/bin/clang"
 
     steps:
       - uses: actions/checkout@v4

--- a/pyapr/data_containers/src/BindAPR.hpp
+++ b/pyapr/data_containers/src/BindAPR.hpp
@@ -16,6 +16,21 @@ namespace py = pybind11;
 
 PYBIND11_MAKE_OPAQUE(std::vector<APR*>)
 
+
+auto _get_y_vec = [](APR& apr) -> py::array {
+    return py::array_t<uint16>(apr.linearAccess.y_vec.size(), apr.linearAccess.y_vec.begin());
+};
+
+auto _get_xz_end_vec = [](APR& apr) -> py::array {
+    return py::array_t<uint64>(apr.linearAccess.xz_end_vec.size(), apr.linearAccess.xz_end_vec.begin());
+};
+
+auto _get_level_xz_vec = [](APR& apr) -> py::array {
+    return py::array_t<uint64>(apr.linearAccess.level_xz_vec.size(), apr.linearAccess.level_xz_vec.begin());
+};
+
+
+
 void AddAPR(pybind11::module &m, const std::string &modulename) {
 
     using namespace py::literals;
@@ -38,7 +53,10 @@ void AddAPR(pybind11::module &m, const std::string &modulename) {
             .def("org_dims", &APR::org_dims, "returns the original image size in a specified dimension (y, x, z)" , "dim"_a)
             .def("shape", [](APR& self){return py::make_tuple(self.org_dims(2), self.org_dims(1), self.org_dims(0));}, "returns the original pixel image dimensions as a tuple (z, x, y)")
             .def("get_parameters", &APR::get_apr_parameters, "return the parameters used to create the APR")
-            .def("computational_ratio", &APR::computational_ratio, "return the computational ratio (number of pixels in original image / number of particles in the APR)");
+            .def("computational_ratio", &APR::computational_ratio, "return the computational ratio (number of pixels in original image / number of particles in the APR)")
+            .def("get_y_vec", _get_y_vec, "return linearAccess y_vec as a numpy array")
+            .def("get_xz_end_vec", _get_xz_end_vec, "return linearAccess xz_end_vec as a numpy array")
+            .def("get_level_xz_vec", _get_level_xz_vec, "return linearAccess level_xz_vec as a numpy array");
 
     py::bind_vector<std::vector<APR*>>(m, "APRPtrVector", py::module_local(false));
 }

--- a/pyapr/utils/filegui.py
+++ b/pyapr/utils/filegui.py
@@ -31,13 +31,19 @@ class DoubleSlider(QtWidgets.QSlider):
         super(DoubleSlider, self).setValue(int(value * self._multi))
 
     def setMinimum(self, value):
-        return super(DoubleSlider, self).setMinimum(value * self._multi)
+        # Convert the result to an integer to comply with the expected type
+        int_value = int(value * self._multi)
+        return super(DoubleSlider, self).setMinimum(int_value)
 
     def setMaximum(self, value):
-        return super(DoubleSlider, self).setMaximum(value * self._multi)
+        # Convert the result to an integer to comply with the expected type
+        int_value = int(value * self._multi)
+        return super(DoubleSlider, self).setMaximum(int_value)
 
     def setSingleStep(self, value):
-        return super(DoubleSlider, self).setSingleStep(value * self._multi)
+        # Convert the result to an integer to comply with the expected type
+        int_value = int(value * self._multi)
+        return super(DoubleSlider, self).setSingleStep(int_value)
 
     def singleStep(self):
         return float(super(DoubleSlider, self).singleStep()) / self._multi
@@ -116,7 +122,7 @@ class MainWindowImage(QtWidgets.QWidget):
 
         self.slider.valueChanged.connect(self.valuechange)
 
-        self.setGeometry(300, 300, self.full_size, self.full_size)
+        self.setGeometry(int(300),  int(300), self.full_size, self.full_size)
 
         self.layout.addWidget(self.slider, 1, 0)
 
@@ -352,7 +358,7 @@ class MainWindowImage(QtWidgets.QWidget):
         self.slider.setMinimum(0)
         self.slider.setMaximum(self.z_num - 1)
         self.slider.setTickPosition(QtWidgets.QSlider.TicksBothSides)
-        self.slider.setGeometry(0.05 * self.full_size, 0.97 * self.full_size, 0.95 * self.full_size, 40)
+        self.slider.setGeometry(int(0.05 * self.full_size), int(0.97 * self.full_size), int(0.95 * self.full_size), int(40))
 
         self.setLUT('viridis')
 

--- a/pyapr/viewer/compressInteractive.py
+++ b/pyapr/viewer/compressInteractive.py
@@ -68,7 +68,7 @@ class CompressWindow(MainWindow):
         self.slider_q.move(200, 70)
         self.slider_q.connectSlider(self.valuechangeQ)
         self.slider_q.maxBox.setValue(20)
-        self.slider_q.slider.setSingleStep(0.1)
+        self.slider_q.slider.setSingleStep(int(1))
 
         self.slider_B = CustomSlider(self, "background")
         self.slider_B.move(200, 100)


### PR DESCRIPTION
## Problem:

A change in the behaviour of our QT based slider dependencies have resulted in a bug due to float values being passed in where the underlying libraries now only support integers. 


## Solution:

Cast the inputs to integers before they reach the slider components. 

Note: This is a patch fix, and could have some un-intended consequences. 

However, the main objective is to get these working agian from a fresh install. 

## Testing:

Worked locally on Windows / WSL. But to be confirmed by Joel before merge. 

